### PR TITLE
#16 Remove user's home directory setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/azkaban-role/tree/develop)
+### Fixed
+- *[#16](https://github.com/idealista/azkaban-role/issues/16) User's home directory setting prevents creating temporary folders* @fabiomx
+
 ### Changed
 - *[#13](https://github.com/idealista/azkaban-role/issues/13) Upgrading Ansible to 2.8.4.0, Molecule to 2.22.0 and Goss to 0.37.0* @dortegau
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -13,7 +13,6 @@
   user:
     name: "{{ azkaban_user }}"
     group: "{{ azkaban_group }}"
-    home: /bin/false
 
 - name: Azkaban | Set server config dir
   set_fact:


### PR DESCRIPTION
### Description of the Change

As seen on issue #16,  user's home directory setting is removed.

### Benefits

Jobs that need to create temporary folders in 'azkaban' user's home directory will be able to do that and will be executed properly.

### Possible Drawbacks

There shouldn't be any drawback.

### Applicable Issues

#16 
